### PR TITLE
changeset: handle unit placement.

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -15,3 +15,37 @@ UnitPlacement = namedtuple(
 
 # Define a relation object.
 Relation = namedtuple('Relation', ['name', 'interface'])
+
+
+def parse_v3_unit_placement(placement):
+    """Return a UnitPlacement for bundles version 3, given a placement string.
+
+    See https://github.com/juju/charmstore/blob/v4/docs/bundles.md
+    """
+    container = machine = service = unit = ''
+    if ':' in placement:
+        container, placement = placement.split(':')
+    if '=' in placement:
+        placement, unit = placement.split('=')
+    if placement.isdigit():
+        machine = placement
+    else:
+        service = placement
+    return UnitPlacement(container, machine, service, unit)
+
+
+def parse_v4_unit_placement(placement):
+    """Return a UnitPlacement for bundles version 4, given a placement string.
+
+    See https://github.com/juju/charmstore/blob/v4/docs/bundles.md
+    """
+    container = machine = service = unit = ''
+    if ':' in placement:
+        container, placement = placement.split(':')
+    if '/' in placement:
+        placement, unit = placement.split('/')
+    if placement.isdigit() or placement == 'new':
+        machine = placement
+    else:
+        service = placement
+    return UnitPlacement(container, machine, service, unit)

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -1,0 +1,71 @@
+from __future__ import unicode_literals
+
+import unittest
+
+from src import models
+
+
+class TestParseV3UnitPlacement(unittest.TestCase):
+
+    def test_success(self):
+        self.assertEqual(
+            models.UnitPlacement('', '', '', ''),
+            models.parse_v3_unit_placement(''),
+        )
+        self.assertEqual(
+            models.UnitPlacement('', '0', '', ''),
+            models.parse_v3_unit_placement('0'),
+        )
+        self.assertEqual(
+            models.UnitPlacement('', '', 'mysql', ''),
+            models.parse_v3_unit_placement('mysql'),
+        )
+        self.assertEqual(
+            models.UnitPlacement('lxc', '0', '', ''),
+            models.parse_v3_unit_placement('lxc:0'),
+        )
+        self.assertEqual(
+            models.UnitPlacement('', '', 'mysql', '1'),
+            models.parse_v3_unit_placement('mysql=1'),
+        )
+        self.assertEqual(
+            models.UnitPlacement('lxc', '', 'mysql', '1'),
+            models.parse_v3_unit_placement('lxc:mysql=1'),
+        )
+
+
+class TestParseV4UnitPlacement(unittest.TestCase):
+
+    def test_success(self):
+        self.assertEqual(
+            models.UnitPlacement('', '', '', ''),
+            models.parse_v4_unit_placement(''),
+        )
+        self.assertEqual(
+            models.UnitPlacement('', '0', '', ''),
+            models.parse_v4_unit_placement('0'),
+        )
+        self.assertEqual(
+            models.UnitPlacement('', '', 'mysql', ''),
+            models.parse_v4_unit_placement('mysql'),
+        )
+        self.assertEqual(
+            models.UnitPlacement('lxc', '0', '', ''),
+            models.parse_v4_unit_placement('lxc:0'),
+        )
+        self.assertEqual(
+            models.UnitPlacement('', '', 'mysql', '1'),
+            models.parse_v4_unit_placement('mysql/1'),
+        )
+        self.assertEqual(
+            models.UnitPlacement('lxc', '', 'mysql', '1'),
+            models.parse_v4_unit_placement('lxc:mysql/1'),
+        )
+        self.assertEqual(
+            models.UnitPlacement('', 'new', '', ''),
+            models.parse_v4_unit_placement('new'),
+        )
+        self.assertEqual(
+            models.UnitPlacement('lxc', 'new', '', ''),
+            models.parse_v4_unit_placement('lxc:new'),
+        )


### PR DESCRIPTION
The addUnit changes now include placement
directives. V4 bundles are fully supported,
still missing support for V3 placement done
by specifying the service name only.