### PR TITLE
Introduce the charm/bundle reference model.

### DIFF
--- a/jujubundlelib/pyutils.py
+++ b/jujubundlelib/pyutils.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+
+import sys
+
+
+# Report whether we are using Python 3 or Python 2.
+PY3 = sys.version_info >= (3, 0)
+
+
+def string_class(cls):
+    """Define __unicode__ and __str__ methods on the given class in Python 2.
+
+    The given class must define a __str__ method returning a unicode string,
+    otherwise a TypeError is raised.
+    Under Python 3, the class is returned as is.
+    """
+    if not PY3:
+        if '__str__' not in cls.__dict__:
+            raise TypeError('the given class has no __str__ method')
+        cls.__unicode__, cls.__string__ = (
+            cls.__str__, lambda self: self.__unicode__().encode('utf-8'))
+    return cls

--- a/jujubundlelib/references.py
+++ b/jujubundlelib/references.py
@@ -1,0 +1,200 @@
+# Copyright 2015 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+
+from __future__ import unicode_literals
+
+import re
+
+from jujubundlelib import pyutils
+
+
+# The URL of jujucharms.com, the home of Juju.
+JUJUCHARMS_URL = 'https://jujucharms.com/'
+
+# The following regular expressions are the same used in juju-core: see
+# http://bazaar.launchpad.net/~go-bot/juju-core/trunk/view/head:/charm/url.go.
+USER_PATTERN = r'[a-z0-9][a-zA-Z0-9+.-]+'
+SERIES_PATTERN = r'[a-z]+(?:[a-z-]+[a-z])?'
+NAME_PATTERN = r'[a-z][a-z0-9]*(?:-[a-z0-9]*[a-z][a-z0-9]*)*'
+
+# Define the callables used to check if entity reference components are valid.
+_valid_user = re.compile(r'^{}$'.format(USER_PATTERN)).match
+_valid_series = re.compile(r'^{}$'.format(SERIES_PATTERN)).match
+_valid_name = re.compile(r'^{}$'.format(NAME_PATTERN)).match
+
+# Compile the regular expression used to parse new jujucharms entity URLs.
+_jujucharms_url_expression = re.compile(r"""
+    ^  # Beginning of the line.
+    (?:
+        (?:{jujucharms})?  # Optional jujucharms.com URL.
+        |
+        /?  # Optional leading slash.
+    )?
+    (?:u/({user_pattern})/)?  # Optional user name.
+    ({name_pattern})  # Bundle name.
+    (?:/({series_pattern}))?  # Optional series.
+    (?:/(\d+))?  # Optional bundle revision number.
+    /?  # Optional trailing slash.
+    $  # End of the line.
+""".format(
+    jujucharms=JUJUCHARMS_URL,
+    name_pattern=NAME_PATTERN,
+    series_pattern=SERIES_PATTERN,
+    user_pattern=USER_PATTERN,
+), re.VERBOSE)
+
+
+@pyutils.string_class
+class Reference(object):
+    """Represent a charm or bundle URL reference."""
+
+    def __init__(self, schema, user, series, name, revision):
+        """Initialize the reference. Receives the URL fragments."""
+        self.schema = schema
+        self.user = user
+        self.series = series
+        self.name = name
+        if revision is not None:
+            revision = int(revision)
+        self.revision = revision
+        # XXX frankban 2015-02-26: remove the following attribute when
+        # switching to the new bundle format, and when we have a better way
+        # to increase bundle deployments count.
+        self.charmworld_id = None
+
+    @classmethod
+    def from_fully_qualified_url(cls, url):
+        """Given an entity URL as a string, create and return a Reference.
+
+        Fully qualified URLs represent the regular entity reference
+        representation in Juju, e.g.: "cs:`~who/vivid/django-42" or
+        "local:bundle/wordpress-0".
+
+        Raise a ValueError if the provided value is not a valid and fully
+        qualified URL, also including the schema and the revision.
+        """
+        return cls(*_parse_fully_qualified_url(url))
+
+    @classmethod
+    def from_jujucharms_url(cls, url):
+        """Create and return a Reference from the given jujucharms.com URL.
+
+        These are the preferred way to refer to a charm or bundle They
+        basically look like the URL paths in jujucharms.com,
+        e.g. "u/who/django", "mediawiki/42" or just "mediawiki". The full HTTP
+        URL can be also provided, for instance "https://jujucharms.com/django".
+
+        Raise a ValueError if the provided URL is not valid.
+        """
+        match = _jujucharms_url_expression.match(url)
+        if match is None:
+            msg = 'invalid bundle URL: {}'.format(url)
+            raise ValueError(msg.encode('utf-8'))
+        user, name, series, revision = match.groups()
+        return cls('cs', user, series or 'bundle', name, revision)
+
+    def __str__(self):
+        """The string representation of a reference is its URL string."""
+        return self.id()
+
+    def __repr__(self):
+        return '<Reference: {}>'.format(self)
+
+    def __eq__(self, other):
+        """Two refs are equal if they have the same string representation."""
+        return isinstance(other, self.__class__) and self.id() == other.id()
+
+    def path(self):
+        """Return the reference as a string without the schema."""
+        user_part = '~{}/'.format(self.user) if self.user else ''
+        revision_part = ''
+        if self.revision is not None:
+            revision_part = '-{}'.format(self.revision)
+        return '{}{}/{}{}'.format(
+            user_part, self.series, self.name, revision_part)
+
+    def id(self):
+        """Return the reference URL as a string."""
+        return '{}:{}'.format(self.schema, self.path())
+
+    def jujucharms_id(self):
+        """Return the identifier of this reference in jujucharms.com."""
+        user_part = 'u/{}/'.format(self.user) if self.user else ''
+        series_part = '' if self.is_bundle() else '/{}'.format(self.series)
+        revision_part = ''
+        if self.revision is not None:
+            revision_part = '/{}'.format(self.revision)
+        return '{}{}{}{}'.format(
+            user_part, self.name, series_part, revision_part)
+
+    def jujucharms_url(self):
+        """Return the URL where this entity lives in jujucharms.com."""
+        return JUJUCHARMS_URL + self.jujucharms_id()
+
+    def is_bundle(self):
+        """Report whether this reference refers to a bundle entity."""
+        return self.series == 'bundle'
+
+    def is_local(self):
+        """Return True if this refers to a local entity, False otherwise."""
+        return self.schema == 'local'
+
+
+def _parse_fully_qualified_url(url):
+    """Parse the given charm or bundle URL, provided as a string.
+
+    Return a tuple containing the entity reference fragments: schema, user,
+    series, name and revision. Each fragment is a string except revision (int).
+
+    Raise a ValueError with a descriptive message if the given URL is not a
+    valid and fully qualified entity URL.
+    """
+    # Retrieve the schema.
+    try:
+        schema, remaining = url.split(':', 1)
+    except ValueError:
+        msg = 'URL has no schema: {}'.format(url)
+        raise ValueError(msg.encode('utf-8'))
+    if schema not in ('cs', 'local'):
+        msg = 'URL has invalid schema: {}'.format(schema)
+        raise ValueError(msg.encode('utf-8'))
+    # Retrieve the optional user, the series, name and revision.
+    parts = remaining.split('/')
+    parts_length = len(parts)
+    if parts_length == 3:
+        user, series, name_revision = parts
+        if not user.startswith('~'):
+            msg = 'URL has invalid user name form: {}'.format(user)
+            raise ValueError(msg.encode('utf-8'))
+        user = user[1:]
+        if not _valid_user(user):
+            msg = 'URL has invalid user name: {}'.format(user)
+            raise ValueError(msg.encode('utf-8'))
+        if schema == 'local':
+            msg = 'local entity URL with user name: {}'.format(url)
+            raise ValueError(msg.encode('utf-8'))
+    elif parts_length == 2:
+        user = ''
+        series, name_revision = parts
+    else:
+        msg = 'URL has invalid form: {}'.format(url)
+        raise ValueError(msg.encode('utf-8'))
+    # Validate the series.
+    if not _valid_series(series):
+        msg = 'URL has invalid series: {}'.format(series)
+        raise ValueError(msg.encode('utf-8'))
+    # Validate name and revision.
+    try:
+        name, revision = name_revision.rsplit('-', 1)
+    except ValueError:
+        msg = 'URL has no revision: {}'.format(url)
+        raise ValueError(msg.encode('utf-8'))
+    if not _valid_name(name):
+        msg = 'URL has invalid name: {}'.format(name)
+        raise ValueError(msg.encode('utf-8'))
+    try:
+        revision = int(revision)
+    except ValueError:
+        msg = 'URL has invalid revision: {}'.format(revision)
+        raise ValueError(msg.encode('utf-8'))
+    return schema, user, series, name, revision

--- a/jujubundlelib/tests/helpers.py
+++ b/jujubundlelib/tests/helpers.py
@@ -1,0 +1,20 @@
+# Copyright 2015 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+
+from __future__ import unicode_literals
+
+from contextlib import contextmanager
+
+
+class ValueErrorTestsMixin(object):
+    """Set up some base methods for testing functions raising ValueErrors."""
+
+    @contextmanager
+    def assert_value_error(self, error):
+        """Ensure a ValueError is raised in the context block.
+
+        Also check that the exception includes the expected error message.
+        """
+        with self.assertRaises(ValueError) as context_manager:
+            yield
+        self.assertEqual(error, context_manager.exception.args[0])

--- a/jujubundlelib/tests/test_pyutils.py
+++ b/jujubundlelib/tests/test_pyutils.py
@@ -1,0 +1,40 @@
+# Copyright 2015 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+
+from __future__ import unicode_literals
+
+import unittest
+
+from jujubundlelib import pyutils
+
+
+class TestStringClass(unittest.TestCase):
+
+    @unittest.skipIf(pyutils.PY3, 'only run under Python 2')
+    def test_python2(self):
+        cls = type(b'Example', (object,), {'__str__': lambda self: 'example'})
+        instance = pyutils.string_class(cls)()
+        byte_string = str(instance)
+        self.assertIsInstance(byte_string, bytes)
+        self.assertEqual(b'example', byte_string)
+        unicode_string = unicode(instance)
+        self.assertNotIsInstance(unicode_string, bytes)
+        self.assertEqual('example', unicode_string)
+
+    @unittest.skipUnless(pyutils.PY3, 'only run under Python 3')
+    def test_python3(self):
+        cls = type('Example', (), {'__str__': lambda self: 'example'})
+        instance = pyutils.string_class(cls)()
+        unicode_string = str(instance)
+        self.assertIsInstance(unicode_string, str)
+        self.assertEqual('example', unicode_string)
+        with self.assertRaises(AttributeError):
+            self.instance.__unicode__()
+
+    @unittest.skipIf(pyutils.PY3, 'only run under Python 2')
+    def test_error(self):
+        non_string_class = type(b'ExampleNonString', (object,), {})
+        with self.assertRaises(TypeError) as ctx:
+            pyutils.string_class(non_string_class)
+        self.assertEqual(
+            'the given class has no __str__ method', str(ctx.exception))

--- a/jujubundlelib/tests/test_references.py
+++ b/jujubundlelib/tests/test_references.py
@@ -1,0 +1,385 @@
+# Copyright 2015 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+
+from __future__ import unicode_literals
+
+import unittest
+
+from jujubundlelib import references
+
+from jujubundlelib.tests import helpers
+
+
+def make_reference(
+        schema='cs', user='myuser', series='precise', name='juju-gui',
+        revision=42):
+    """Create and return a Reference instance."""
+    return references.Reference(schema, user, series, name, revision)
+
+
+class TestReference(unittest.TestCase):
+
+    def test_attributes(self):
+        # All reference attributes are correctly stored.
+        ref = make_reference()
+        self.assertEqual('cs', ref.schema)
+        self.assertEqual('myuser', ref.user)
+        self.assertEqual('precise', ref.series)
+        self.assertEqual('juju-gui', ref.name)
+        self.assertEqual(42, ref.revision)
+
+    def test_revision_as_string(self):
+        # The reference revision is converted to an int.
+        ref = make_reference(revision='47')
+        self.assertEqual(47, ref.revision)
+
+    def test_string(self):
+        # The string representation of a reference is its URL.
+        tests = (
+            (make_reference(),
+             'cs:~myuser/precise/juju-gui-42'),
+            (make_reference(schema='local'),
+             'local:~myuser/precise/juju-gui-42'),
+            (make_reference(user=''),
+             'cs:precise/juju-gui-42'),
+            (make_reference(user='dalek', revision=None, series='bundle'),
+             'cs:~dalek/bundle/juju-gui'),
+            (make_reference(name='django', series='vivid', revision=0),
+             'cs:~myuser/vivid/django-0'),
+            (make_reference(user='', revision=None),
+             'cs:precise/juju-gui'),
+        )
+        for ref, expected_value in tests:
+            self.assertEqual(expected_value, str(ref))
+
+    def test_repr(self):
+        # A reference is correctly represented.
+        tests = (
+            (make_reference(),
+             '<Reference: cs:~myuser/precise/juju-gui-42>'),
+            (make_reference(schema='local'),
+             '<Reference: local:~myuser/precise/juju-gui-42>'),
+            (make_reference(user=''),
+             '<Reference: cs:precise/juju-gui-42>'),
+            (make_reference(user='dalek', revision=None, series='bundle'),
+             '<Reference: cs:~dalek/bundle/juju-gui>'),
+            (make_reference(name='django', series='vivid', revision=0),
+             '<Reference: cs:~myuser/vivid/django-0>'),
+            (make_reference(user='', revision=None),
+             '<Reference: cs:precise/juju-gui>'),
+        )
+        for ref, expected_value in tests:
+            self.assertEqual(expected_value, repr(ref))
+
+    def test_path(self):
+        # The reference path is properly returned as a URL string without the
+        # schema.
+        tests = (
+            (make_reference(),
+             '~myuser/precise/juju-gui-42'),
+            (make_reference(schema='local'),
+             '~myuser/precise/juju-gui-42'),
+            (make_reference(user=''),
+             'precise/juju-gui-42'),
+            (make_reference(user='dalek', revision=None, series='bundle'),
+             '~dalek/bundle/juju-gui'),
+            (make_reference(name='django', series='vivid', revision=0),
+             '~myuser/vivid/django-0'),
+            (make_reference(user='', revision=None),
+             'precise/juju-gui'),
+        )
+        for ref, expected_value in tests:
+            self.assertEqual(expected_value, ref.path())
+
+    def test_id(self):
+        # The reference id is correctly returned.
+        tests = (
+            (make_reference(),
+             'cs:~myuser/precise/juju-gui-42'),
+            (make_reference(schema='local'),
+             'local:~myuser/precise/juju-gui-42'),
+            (make_reference(user=''),
+             'cs:precise/juju-gui-42'),
+            (make_reference(user='dalek', revision=None, series='bundle'),
+             'cs:~dalek/bundle/juju-gui'),
+            (make_reference(name='django', series='vivid', revision=0),
+             'cs:~myuser/vivid/django-0'),
+            (make_reference(user='', revision=None),
+             'cs:precise/juju-gui'),
+        )
+        for ref, expected_value in tests:
+            self.assertEqual(expected_value, ref.id())
+
+    def test_jujucharms_id(self):
+        # It is possible to return the reference identifier in jujucharms.com.
+        tests = (
+            (make_reference(),
+             'u/myuser/juju-gui/precise/42'),
+            (make_reference(schema='local'),
+             'u/myuser/juju-gui/precise/42'),
+            (make_reference(user=''),
+             'juju-gui/precise/42'),
+            (make_reference(user='dalek', revision=None, series='bundle'),
+             'u/dalek/juju-gui'),
+            (make_reference(name='django', series='vivid', revision=0),
+             'u/myuser/django/vivid/0'),
+            (make_reference(user='', revision=None),
+             'juju-gui/precise'),
+            (make_reference(user='', series='bundle', revision=None),
+             'juju-gui'),
+        )
+        for ref, expected_value in tests:
+            self.assertEqual(expected_value, ref.jujucharms_id())
+
+    def test_jujucharms_url(self):
+        # The corresponding charm or bundle page in jujucharms.com is correctly
+        # returned.
+        tests = (
+            (make_reference(),
+             'u/myuser/juju-gui/precise/42'),
+            (make_reference(schema='local'),
+             'u/myuser/juju-gui/precise/42'),
+            (make_reference(user=''),
+             'juju-gui/precise/42'),
+            (make_reference(user='dalek', revision=None, series='bundle'),
+             'u/dalek/juju-gui'),
+            (make_reference(name='django', series='vivid', revision=0),
+             'u/myuser/django/vivid/0'),
+            (make_reference(user='', revision=None),
+             'juju-gui/precise'),
+            (make_reference(user='', series='bundle', revision=None),
+             'juju-gui'),
+        )
+        for ref, expected_value in tests:
+            expected_url = references.JUJUCHARMS_URL + expected_value
+            self.assertEqual(expected_url, ref.jujucharms_url())
+
+    def test_charm_entity(self):
+        # The is_bundle method returns False for charm references.
+        ref = make_reference(series='vivid')
+        self.assertFalse(ref.is_bundle())
+
+    def test_bundle_entity(self):
+        # The is_bundle method returns True for bundle references.
+        ref = make_reference(series='bundle')
+        self.assertTrue(ref.is_bundle())
+
+    def test_charm_store_entity(self):
+        # The is_local method returns False for charm store references.
+        ref = make_reference(schema='cs')
+        self.assertFalse(ref.is_local())
+
+    def test_local_entity(self):
+        # The is_local method returns True for local references.
+        ref = make_reference(schema='local')
+        self.assertTrue(ref.is_local())
+
+    def test_equality(self):
+        # Two references are equal if they have the same URL.
+        self.assertEqual(make_reference(), make_reference())
+        self.assertEqual(make_reference(user=''), make_reference(user=''))
+        self.assertEqual(
+            make_reference(revision=None), make_reference(revision=None))
+
+    def test_equality_different_references(self):
+        # Two references with different attributes are not equal.
+        tests = (
+            (make_reference(schema='cs'),
+             make_reference(schema='local')),
+            (make_reference(user=''),
+             make_reference(user='who')),
+            (make_reference(series='trusty'),
+             make_reference(series='vivid')),
+            (make_reference(name='django'),
+             make_reference(name='rails')),
+            (make_reference(revision=0),
+             make_reference(revision=1)),
+            (make_reference(revision=None),
+             make_reference(revision=42)),
+        )
+        for ref1, ref2 in tests:
+            self.assertNotEqual(ref1, ref2)
+
+    def test_equality_different_types(self):
+        # A reference never equals a non-reference object.
+        self.assertNotEqual(make_reference(), 42)
+        self.assertNotEqual(make_reference(), True)
+        self.assertNotEqual(make_reference(), 'oranges')
+
+    def test_charmworld_id(self):
+        # By default, the reference id in charmworld is set to None.
+        # XXX frankban 2015-02-26: remove this test once we get rid of the
+        # charmworld id concept.
+        ref = make_reference()
+        self.assertIsNone(ref.charmworld_id)
+
+
+class TestReferenceFromFullyQualifiedUrl(
+        helpers.ValueErrorTestsMixin, unittest.TestCase):
+
+    def test_no_schema_error(self):
+        # A ValueError is raised if the URL schema is missing.
+        expected_error = b'URL has no schema: precise/juju-gui'
+        with self.assert_value_error(expected_error):
+            references.Reference.from_fully_qualified_url('precise/juju-gui')
+
+    def test_invalid_schema_error(self):
+        # A ValueError is raised if the URL schema is not valid.
+        expected_error = b'URL has invalid schema: http'
+        with self.assert_value_error(expected_error):
+            references.Reference.from_fully_qualified_url(
+                'http:precise/juju-gui')
+
+    def test_invalid_user_form_error(self):
+        # A ValueError is raised if the user form is not valid.
+        expected_error = b'URL has invalid user name form: jean-luc'
+        with self.assert_value_error(expected_error):
+            references.Reference.from_fully_qualified_url(
+                'cs:jean-luc/precise/juju-gui')
+
+    def test_invalid_user_name_error(self):
+        # A ValueError is raised if the user name is not valid.
+        expected_error = b'URL has invalid user name: jean:luc'
+        with self.assert_value_error(expected_error):
+            references.Reference.from_fully_qualified_url(
+                'cs:~jean:luc/precise/juju-gui')
+
+    def test_local_user_name_error(self):
+        # A ValueError is raised if a user is specified on a local entity.
+        expected_error = (
+            b'local entity URL with user name: '
+            b'local:~jean-luc/precise/juju-gui')
+        with self.assert_value_error(expected_error):
+            references.Reference.from_fully_qualified_url(
+                'local:~jean-luc/precise/juju-gui')
+
+    def test_invalid_form_error(self):
+        # A ValueError is raised if the URL is not valid.
+        expected_error = b'URL has invalid form: cs:~user/series/name/what-?'
+        with self.assert_value_error(expected_error):
+            references.Reference.from_fully_qualified_url(
+                'cs:~user/series/name/what-?')
+
+    def test_invalid_series_error(self):
+        # A ValueError is raised if the series is not valid.
+        expected_error = b'URL has invalid series: boo!'
+        with self.assert_value_error(expected_error):
+            references.Reference.from_fully_qualified_url(
+                'cs:boo!/juju-gui-42')
+
+    def test_no_revision_error(self):
+        # A ValueError is raised if the entity revision is missing.
+        expected_error = b'URL has no revision: cs:series/name'
+        with self.assert_value_error(expected_error):
+            references.Reference.from_fully_qualified_url('cs:series/name')
+
+    def test_invalid_revision_error(self):
+        # A ValueError is raised if the charm or bundle revision is not valid.
+        expected_error = b'URL has invalid revision: revision'
+        with self.assert_value_error(expected_error):
+            references.Reference.from_fully_qualified_url(
+                'cs:series/name-revision')
+
+    def test_invalid_name_error(self):
+        # A ValueError is raised if the entity name is not valid.
+        expected_error = b'URL has invalid name: not:valid'
+        with self.assert_value_error(expected_error):
+            references.Reference.from_fully_qualified_url(
+                'cs:precise/not:valid-42')
+
+    def test_success(self):
+        # References are correctly instantiated by parsing the fully qualified
+        # URL.
+        tests = (
+            ('cs:~myuser/precise/juju-gui-42',
+             make_reference()),
+            ('cs:trusty/juju-gui-42',
+             make_reference(user='', series='trusty')),
+            ('local:precise/juju-gui-42',
+             make_reference(schema='local', user='')),
+        )
+        for url, expected_ref in tests:
+            ref = references.Reference.from_fully_qualified_url(url)
+            self.assertEqual(expected_ref, ref)
+
+
+class TestReferenceFromJujucharmsUrl(
+        helpers.ValueErrorTestsMixin, unittest.TestCase):
+
+    def test_invalid_form(self):
+        # A ValueError is raised if the URL is not valid.
+        expected_error = b'invalid bundle URL: bad wolf'
+        with self.assert_value_error(expected_error):
+            references.Reference.from_jujucharms_url('bad wolf')
+
+    def test_success(self):
+        # A reference is correctly created from a jujucharms.com identifier or
+        # complete URL.
+        tests = (
+            # Check with both user and revision.
+            ('u/myuser/mediawiki/42',
+             make_reference(series='bundle', name='mediawiki')),
+            ('/u/myuser/mediawiki/42',
+             make_reference(series='bundle', name='mediawiki')),
+            ('u/myuser/django-scalable/42/',
+             make_reference(series='bundle', name='django-scalable')),
+            ('{}u/myuser/mediawiki/42'.format(references.JUJUCHARMS_URL),
+             make_reference(series='bundle', name='mediawiki')),
+            ('{}u/myuser/mediawiki/42/'.format(references.JUJUCHARMS_URL),
+             make_reference(series='bundle', name='mediawiki')),
+
+            # Check without revision.
+            ('u/myuser/mediawiki',
+             make_reference(series='bundle', name='mediawiki', revision=None)),
+            ('/u/myuser/wordpress',
+             make_reference(series='bundle', name='wordpress', revision=None)),
+            ('u/myuser/mediawiki/',
+             make_reference(series='bundle', name='mediawiki', revision=None)),
+            ('{}u/myuser/django'.format(references.JUJUCHARMS_URL),
+             make_reference(series='bundle', name='django', revision=None)),
+            ('{}u/myuser/mediawiki/'.format(references.JUJUCHARMS_URL),
+             make_reference(series='bundle', name='mediawiki', revision=None)),
+
+            # Check without the user.
+            ('rails-single/42',
+             make_reference(user='', series='bundle', name='rails-single')),
+            ('/mediawiki/42',
+             make_reference(user='', series='bundle', name='mediawiki')),
+            ('rails-scalable/42/',
+             make_reference(user='', series='bundle', name='rails-scalable')),
+            ('{}mediawiki/42'.format(references.JUJUCHARMS_URL),
+             make_reference(user='', series='bundle', name='mediawiki')),
+            ('{}django/42/'.format(references.JUJUCHARMS_URL),
+             make_reference(user='', series='bundle', name='django')),
+
+            # Check without user and revision.
+            ('mediawiki',
+             make_reference(user='', series='bundle', name='mediawiki',
+                            revision=None)),
+            ('/wordpress',
+             make_reference(user='', series='bundle', name='wordpress',
+                            revision=None)),
+            ('mediawiki/',
+             make_reference(user='', series='bundle', name='mediawiki',
+                            revision=None)),
+            ('{}django'.format(references.JUJUCHARMS_URL),
+             make_reference(user='', series='bundle', name='django',
+                            revision=None)),
+            ('{}mediawiki/'.format(references.JUJUCHARMS_URL),
+             make_reference(user='', series='bundle', name='mediawiki',
+                            revision=None)),
+
+            # Check charm entities.
+            ('mediawiki/trusty/0',
+             make_reference(user='', series='trusty', name='mediawiki',
+                            revision=0)),
+            ('/wordpress/precise',
+             make_reference(user='', series='precise', name='wordpress',
+                            revision=None)),
+            ('u/who/rails/vivid',
+             make_reference(user='who', series='vivid', name='rails',
+                            revision=None)),
+        )
+        for url, expected_ref in tests:
+            ref = references.Reference.from_jujucharms_url(url)
+            self.assertEqual(expected_ref, ref)


### PR DESCRIPTION
The references module is taken from Juju Quickstart, with just some tweaks and fixes for Python 2/3 handling. This will be used when validating a bundle.