### PR TITLE
Improve bundle validation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,14 @@ clean:
 docs: setup
 	tox -e docs
 
+.PHONY: fcheck
+fcheck: setup
+	$(MAKE) check JUJU_BUNDLELIB_FTESTS=1
+
+.PHONY: ftest
+ftest: setup
+	$(MAKE) test JUJU_BUNDLELIB_FTESTS=1
+
 .PHONY: help
 help:
 	@echo -e 'Juju Bundle Lib - list of make targets:\n'
@@ -64,6 +72,8 @@ help:
 	@echo 'make source - Create source package.'
 	@echo 'make clean - Get rid of bytecode files, build and dist dirs, venvs.'
 	@echo 'make release - Register and upload a release on PyPI.'
+	@echo 'make ftest - Run tests (including functional tests).'
+	@echo 'make fcheck - Run all Py2/Py3 tests (including functional tests).'
 	@echo -e '\nAfter creating the development environment with "make", it is'
 	@echo 'also possible to do the following:'
 	@echo '- run a specific subset of the test suite, e.g. with'

--- a/jujubundlelib/__init__.py
+++ b/jujubundlelib/__init__.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 
 
-VERSION = (0, 1, 4)
+VERSION = (0, 1, 5)
 
 
 def get_version():

--- a/jujubundlelib/models.py
+++ b/jujubundlelib/models.py
@@ -30,6 +30,7 @@ def parse_v3_unit_placement(placement_str):
     """Return a UnitPlacement for bundles version 3, given a placement string.
 
     See https://github.com/juju/charmstore/blob/v4/docs/bundles.md
+    Raise a ValueError if the placement is not valid.
     """
     placement = placement_str
     container = machine = service = unit = ''
@@ -55,12 +56,7 @@ def parse_v3_unit_placement(placement_str):
         msg = 'invalid container {} for placement {}'.format(
             container, placement_str)
         raise ValueError(msg.encode('utf-8'))
-    if unit:
-        try:
-            unit = int(unit)
-        except (TypeError, ValueError):
-            msg = 'unit in placement {} must be digit'.format(placement_str)
-            raise ValueError(msg.encode('utf-8'))
+    unit = _parse_unit(unit, placement_str)
     if machine and machine != '0':
         raise ValueError(b'legacy bundles may not place units on machines '
                          b'other than 0')
@@ -71,6 +67,7 @@ def parse_v4_unit_placement(placement_str):
     """Return a UnitPlacement for bundles version 4, given a placement string.
 
     See https://github.com/juju/charmstore/blob/v4/docs/bundles.md
+    Raise a ValueError if the placement is not valid.
     """
     placement = placement_str
     container = machine = service = unit = ''
@@ -96,22 +93,20 @@ def parse_v4_unit_placement(placement_str):
         msg = 'invalid container {} for placement {}'.format(
             container, placement_str)
         raise ValueError(msg.encode('utf-8'))
-    if unit:
-        try:
-            unit = int(unit)
-        except (TypeError, ValueError):
-            msg = 'unit in placement {} must be digit'.format(placement_str)
-            raise ValueError(msg.encode('utf-8'))
+    unit = _parse_unit(unit, placement_str)
     return UnitPlacement(container, machine, service, unit)
 
 
-def normalize_machines(machines):
-    """Normalize the machines spec to use integer keys."""
-    normalized_machines = {}
+def _parse_unit(unit, placement_str):
+    """Parse a unit as part of the unit placement.
+
+    Return the unit as an integer or None.
+    Raise a ValueError if the unit is specified but it is not a digit.
+    """
+    if not unit:
+        return None
     try:
-        for k, v in machines.items():
-            normalized_machines[int(k)] = v
-    except (TypeError, AttributeError, ValueError):
-        msg = 'Malformed machines {}'.format(machines)
+        return int(unit)
+    except (TypeError, ValueError):
+        msg = 'unit in placement {} must be digit'.format(placement_str)
         raise ValueError(msg.encode('utf-8'))
-    return normalized_machines

--- a/jujubundlelib/tests/test_cli.py
+++ b/jujubundlelib/tests/test_cli.py
@@ -19,11 +19,16 @@ class TestGetChangeset(helpers.BundleFileTestsMixin, unittest.TestCase):
         self.assertTrue(mock_print.called)
 
     def test_invalid_bundle(self, mock_print):
-        path = self.make_bundle_file("series: bad@wolf\nservices: 'oh nooooo'")
+        path = self.make_bundle_file({
+            'series': 42,
+            'services': {'django': {}},
+        })
+        expected_error = (
+            'bundle series must be a string, found 42\n'
+            'no charm specified for service django')
         error = cli.get_changeset([path])
-        self.assertEqual(
-            error, 'bundle has invalid series bad@wolf\n'
-            'services spec does not appear to be well-formed')
+        print(error)
+        self.assertEqual(expected_error, error)
 
     def test_invalid_yaml(self, mock_print):
         path = self.make_bundle_file(content=':')

--- a/jujubundlelib/tests/test_integration.py
+++ b/jujubundlelib/tests/test_integration.py
@@ -1,0 +1,85 @@
+# Copyright 2015 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+
+from __future__ import (
+    print_function,
+    unicode_literals,
+)
+
+import json
+import os
+import pprint
+import unittest
+try:
+    from urllib.request import (
+        HTTPError,
+        urlopen,
+    )
+except ImportError:
+    from urllib2 import (
+        HTTPError,
+        urlopen,
+    )
+
+import yaml
+
+from jujubundlelib import (
+    changeset,
+    references,
+    validation,
+)
+
+
+# Define the URL to the charm store API.
+CHARMSTORE_URL = 'https://api.jujucharms.com/charmstore/v4/'
+# Define the name of the environment variable used to run the functional tests.
+FTEST_ENV_VAR = 'JUJU_BUNDLELIB_FTESTS'
+
+
+def get_references():
+    """Retrieve the bundle references from the charm store."""
+    response = urlopen(CHARMSTORE_URL + 'search?series=bundle&limit=10000')
+    content = response.read().decode('utf-8')
+    data = json.loads(content)
+    for result in data['Results']:
+        yield references.Reference.from_fully_qualified_url(result['Id'])
+
+
+def get_bundle(reference):
+    """Retrieve the bundle content for the given reference from the store."""
+    response = urlopen(
+        CHARMSTORE_URL + reference.path() + '/archive/bundle.yaml')
+    return yaml.load(response)
+
+
+skip_if_ftests_disabled = unittest.skipUnless(
+    os.getenv(FTEST_ENV_VAR) == '1',
+    'to run functional tests, set {} to "1"'.format(FTEST_ENV_VAR))
+
+
+@skip_if_ftests_disabled
+class TestFunctional(unittest.TestCase):
+
+    def setUp(self):
+        # Collect bundles from the charm store.
+        self.references = get_references()
+
+    def test_bundle(self):
+        # All the charm store bundles pass validation.
+        # It is possible to get the change set corresponding to each bundle.
+        # This test ensures there are no false positives when validating a
+        # bundle: charm store bundles are assumed to be valid.
+        # Note that this test requires network connection.
+        for ref in self.references:
+            try:
+                bundle = get_bundle(ref)
+            except HTTPError as err:
+                print('skipping {}: {}'.format(ref, err))
+                continue
+            errors = validation.validate(bundle)
+            self.assertEqual(
+                [], errors,
+                'ref: {}\n{}\nerrors: {}'.format(
+                    ref, pprint.pformat(bundle), errors))
+            changes = changeset.parse(bundle)
+            self.assertTrue(changes)

--- a/jujubundlelib/tests/test_models.py
+++ b/jujubundlelib/tests/test_models.py
@@ -14,19 +14,19 @@ class TestParseV3UnitPlacement(
 
     def test_success(self):
         self.assertEqual(
-            models.UnitPlacement('', '', '', ''),
+            models.UnitPlacement('', '', '', None),
             models.parse_v3_unit_placement(''),
         )
         self.assertEqual(
-            models.UnitPlacement('', '0', '', ''),
+            models.UnitPlacement('', '0', '', None),
             models.parse_v3_unit_placement('0'),
         )
         self.assertEqual(
-            models.UnitPlacement('', '', 'mysql', ''),
+            models.UnitPlacement('', '', 'mysql', None),
             models.parse_v3_unit_placement('mysql'),
         )
         self.assertEqual(
-            models.UnitPlacement('lxc', '0', '', ''),
+            models.UnitPlacement('lxc', '0', '', None),
             models.parse_v3_unit_placement('lxc:0'),
         )
         self.assertEqual(
@@ -77,19 +77,19 @@ class TestParseV4UnitPlacement(
 
     def test_success(self):
         self.assertEqual(
-            models.UnitPlacement('', '', '', ''),
+            models.UnitPlacement('', '', '', None),
             models.parse_v4_unit_placement(''),
         )
         self.assertEqual(
-            models.UnitPlacement('', '0', '', ''),
+            models.UnitPlacement('', '0', '', None),
             models.parse_v4_unit_placement('0'),
         )
         self.assertEqual(
-            models.UnitPlacement('', '', 'mysql', ''),
+            models.UnitPlacement('', '', 'mysql', None),
             models.parse_v4_unit_placement('mysql'),
         )
         self.assertEqual(
-            models.UnitPlacement('lxc', '0', '', ''),
+            models.UnitPlacement('lxc', '0', '', None),
             models.parse_v4_unit_placement('lxc:0'),
         )
         self.assertEqual(
@@ -101,11 +101,11 @@ class TestParseV4UnitPlacement(
             models.parse_v4_unit_placement('lxc:mysql/1'),
         )
         self.assertEqual(
-            models.UnitPlacement('', 'new', '', ''),
+            models.UnitPlacement('', 'new', '', None),
             models.parse_v4_unit_placement('new'),
         )
         self.assertEqual(
-            models.UnitPlacement('lxc', 'new', '', ''),
+            models.UnitPlacement('lxc', 'new', '', None),
             models.parse_v4_unit_placement('lxc:new'),
         )
 
@@ -135,35 +135,3 @@ class TestParseV4UnitPlacement(
         for test in tests:
             with self.assert_value_error(test['error'], test['about']):
                 models.parse_v4_unit_placement(test['placement'])
-
-
-class TestNormalizeMachines(
-        helpers.ValueErrorTestsMixin, unittest.TestCase):
-
-    def test_success(self):
-        provided = {
-            '0': {
-                'series': 'precise',
-            },
-            '1': {
-                'series': 'trusty',
-                'constraints': 'mem=foo',
-            },
-        }
-        expected = {
-            0: {
-                'series': 'precise',
-            },
-            1: {
-                'series': 'trusty',
-                'constraints': 'mem=foo',
-            },
-        }
-        self.assertEqual(models.normalize_machines(provided), expected)
-        self.assertEqual(models.normalize_machines(expected), expected)
-
-    def test_failure(self):
-        with self.assert_value_error(b'Malformed machines None'):
-            models.normalize_machines(None)
-        with self.assert_value_error(b'Malformed machines bad-wolf'):
-            models.normalize_machines('bad-wolf')

--- a/jujubundlelib/tests/test_typeutils.py
+++ b/jujubundlelib/tests/test_typeutils.py
@@ -1,0 +1,48 @@
+# Copyright 2015 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+
+from __future__ import unicode_literals
+
+import collections
+import unittest
+
+from jujubundlelib import typeutils
+
+
+class TestIsdict(unittest.TestCase):
+
+    def test_dict(self):
+        for value in ({}, collections.OrderedDict()):
+            self.assertTrue(typeutils.isdict(value), str(value))
+
+    def test_non_dict(self):
+        for value in ('', [1, 2], 42, None, object()):
+            self.assertFalse(typeutils.isdict(value), str(value))
+
+
+class TestIslist(unittest.TestCase):
+
+    def test_list(self):
+        tests = (
+            [1, 2],
+            (),
+            ('foo', 'bar'),
+            collections.namedtuple('Test', 'test')('test'),
+        )
+        for value in tests:
+            self.assertTrue(typeutils.islist(value), str(value))
+
+    def test_non_list(self):
+        for value in ('', {}, 42, None, object()):
+            self.assertFalse(typeutils.islist(value), str(value))
+
+
+class TestIsstring(unittest.TestCase):
+
+    def test_string(self):
+        for value in ('', 'foo', b'bar'):
+            self.assertTrue(typeutils.isstring(value), str(value))
+
+    def test_non_string(self):
+        for value in ([1, 2], {}, 42, None, object()):
+            self.assertFalse(typeutils.isstring(value), str(value))

--- a/jujubundlelib/typeutils.py
+++ b/jujubundlelib/typeutils.py
@@ -1,0 +1,24 @@
+# Copyright 2015 Canonical Ltd.
+# Licensed under the AGPLv3, see LICENCE file for details.
+
+from __future__ import unicode_literals
+
+import collections
+
+from jujubundlelib import pyutils
+
+
+def isdict(value):
+    """Report whether the given value is a dict-like object."""
+    return isinstance(value, collections.Mapping)
+
+
+def islist(value):
+    """Report whether the given value is a sequence."""
+    return isinstance(value, (list, tuple))
+
+
+def isstring(value):
+    """Report whether the given value is a byte or unicode string."""
+    classes = (str, bytes) if pyutils.PY3 else basestring
+    return isinstance(value, classes)

--- a/jujubundlelib/validation.py
+++ b/jujubundlelib/validation.py
@@ -3,273 +3,395 @@
 
 from __future__ import unicode_literals
 
-import collections
-
 import models
 import pyutils
 import references
-import utils
+from typeutils import (
+    isdict,
+    islist,
+    isstring,
+)
 
 
-class BundleValidator(object):
-    """Maintain a state of bundle validation.
-
-    The state includes the bundle dict and the errors list.
-    """
-
-    def __init__(self, bundle):
-        self.bundle = bundle
-        self._errors = []
-
-    def add_error(self, error):
-        """Add an error to the list of validation errors."""
-        self._errors.append(error)
-
-    def errors(self):
-        """Return the list of all errors produced during validation"""
-        return self._errors
-
-    def is_legacy_bundle(self):
-        """Report whether the bundle uses the legacy (version 3) syntax."""
-        return utils.is_legacy_bundle(self.bundle)
+# Define accepted constraint types.
+_CONSTRAINTS = (
+    'arch',
+    'container',
+    'cpu',
+    'cpu-cores',
+    'cpu-power',
+    'instance-type',
+    'mem',
+    'networks',
+    'root-disk',
+    'tags',
+)
 
 
 def validate(bundle):
-    """Validate a bundle object and all of its components."""
-    if not isinstance(bundle, collections.Mapping):
-        return ['bundle does not appear to be a bundle']
-    validator = BundleValidator(bundle)
-    try:
-        machines = models.normalize_machines(bundle.get('machines', {}))
-    except ValueError:
-        return ['machines spec does not appear to be well-formed']
-    machines_used = dict((i, False) for i in machines)
-    services = bundle.get('services')
+    """Validate a bundle object and all of its components.
+
+    The bundle must be passed as a YAML decoded object.
+
+    Return a list of bundle errors, or an empty list if the bundle is valid.
+    """
+    errors = []
+    add_error = errors.append
+
+    # Check that the bundle sections are well formed.
+    series, services, machines, relations = _validate_sections(
+        bundle, add_error)
+    # If there are errors already, there is no point in proceeding with the
+    # validation process.
+    if errors:
+        return errors
+
+    # Validate each individual section.
+    _validate_series(series, 'bundle', add_error)
+    _validate_services(services, machines, add_error)
+    _validate_machines(machines, add_error)
+    _validate_relations(relations, services, add_error)
+
+    # Return all the collected errors.
+    return errors
+
+
+def _validate_sections(bundle, add_error):
+    """Check that the base bundle sections are valid.
+
+    The bundle argument is a YAML decoded bundle content.
+
+    A bundle is composed of series, services, machines and relations.
+    Only the services section is mandatory.
+
+    Use the given add_error callable to register validation error.
+    Return the four sections
+    """
+    # Check that the bundle itself is well formed.
+    if not isdict(bundle):
+        add_error('bundle does not appear to be a bundle')
+        return None, None, None, None
+    # Validate the services section.
+    services = bundle.get('services', {})
     if not services:
-        return ['bundle does not define any services']
-
-    series = validator.bundle.get('series')
-    if series and not valid_series(series):
-        validator.add_error(
-            'bundle has invalid series {}'.format(series))
-    validate_machines(validator, machines)
-    validate_services(validator, machines,
-                      machines_used=machines_used)
-    validate_relations(validator)
-
-    for machine, used in machines_used.items():
-        if not used:
-            validator.add_error(
-                'machine {} not referred to by a placement '
-                'directive'.format(machine))
-    return validator.errors()
-
-
-def valid_series(series):
-    """Validate a series of some entity."""
-    return references.valid_series(series) and series != 'bundle'
+        add_error('bundle does not define any services')
+    elif not isdict(services):
+        add_error('services spec does not appear to be well-formed')
+    # Validate the machines section.
+    machines = bundle.get('machines')
+    if machines is not None:
+        if isdict(machines):
+            try:
+                machines = dict((int(k), v) for k, v in machines.items())
+            except (TypeError, ValueError):
+                add_error('machines spec identifiers must be digits')
+        else:
+            add_error('machines spec does not appear to be well-formed')
+    # Validate the relations section.
+    relations = bundle.get('relations')
+    if (relations is not None) and (not islist(relations)):
+        add_error('relations spec does not appear to be well-formed')
+    return bundle.get('series'), services, machines, relations
 
 
-def valid_constraints(constraints):
-    """Validate a constraints string."""
-    constraint_types = (
-        'arch',
-        'cpu-cores',
-        'mem',
-        'root-disk',
-        'container',
-        'cpu-power',
-        'tags',
-        'networks',
-        'instance-type',
-    )
-    if constraints:
-        constraints = constraints.split()
-        for constraint in constraints:
-            parts = constraint.split('=')
-            if (len(parts) != 2 or
-                    not parts[1] or
-                    parts[0] not in constraint_types):
-                return False
-    return True
+def _validate_series(series, label, add_error):
+    """Check that the given series is valid.
+
+    Use the given label (e.g. "machine X" or just "bundle") to describe
+    possible errors.
+    Use the given add_error callable to register validation error.
+    """
+    if series is None:
+        return
+    if not isstring(series):
+        add_error('{} series must be a string, found {}'.format(label, series))
+        return
+    if series == 'bundle':
+        add_error('{} series must specify a charm series'.format(label))
+        return
+    if not references.valid_series(series):
+        add_error('{} has invalid series {}'.format(label, series))
 
 
-def validate_machines(validator, machines):
-    """Validate the machines object within the context of the bundle."""
-    for machine_id, machine in machines.items():
-        try:
-            int_id = int(machine_id)
-            if int_id < 0:
-                validator.add_error(
-                    'machine {} has an invalid id, must be positive '
-                    'digit'.format(
-                        machine_id))
-        except (TypeError, ValueError):
-            validator.add_error(
-                'machine {} has an invalid id, must be digit'.format(
-                    machine_id))
-        if ('constraints' in machine and
-                not valid_constraints(machine['constraints'])):
-            validator.add_error(
-                'machine {} has invalid constraints {}'.format(
-                    machine_id, machine['constraints']))
-        if ('series' in machine and
-                not valid_series(machine['series'])):
-            validator.add_error(
-                'machine {} has invalid series {}'.format(
-                    machine_id, machine['series']))
-        if ('annotations' in machine and
-                not isinstance(machine['annotations'], collections.Mapping)):
-            validator.add_error(
-                'machine {} has invalid annotations {}'.format(
-                    machine_id, machine['annotations']))
-
-
-def validate_services(validator, machines, machines_used={}):
+def _validate_services(services, machines, add_error):
     """Validate each service within the bundle.
 
-    if machines_used is supplied, then machines in the dict will be marked
-    as used, allowing validation that all machines in the machine spec have
-    been used.
+    Receive the services and machines sections of the bundle.
+    Use the given add_error callable to register validation error.
     """
-    services = validator.bundle.get('services')
-    if not isinstance(services, collections.Mapping):
-        validator.add_error('services spec does not appear to be well-formed')
-        return
+    machine_ids = set()
+
     for service_name, service in services.items():
-        charm_url = service.get('charm')
-        if charm_url is None:
-            charm = None
-            validator.add_error(
-                'no charm specified for service {}'.format(service_name))
-        else:
-            try:
-                charm = references.Reference.from_string(charm_url)
-            except ValueError as e:
-                validator.add_error(
-                    'invalid charm specified for service {}: {}'.format(
-                        service_name, pyutils.exception_string(e)))
-                charm = None
-            else:
-                if charm.is_local():
-                    validator.add_error(
-                        'local charms not allowed for service {}: {}'.format(
-                            service_name, charm))
-                if charm.is_bundle():
-                    validator.add_error(
-                        'bundles not allowed for service {}: {}'.format(
-                            service_name, charm))
-        if ('constraints' in service and
-                not valid_constraints(service['constraints'])):
-            validator.add_error(
-                'service {} has invalid constraints {}'.format(
-                    service_name, service['constraints']))
-        num_units = service.get('num_units')
-        if not isinstance(num_units, int):
-            validator.add_error(
-                'num_units for service {} must be an integer'.format(
-                    service_name))
-            num_units = None
-        elif num_units < 0:
-            validator.add_error(
-                'invalid units for service {}: {}'.format(
-                    service_name, service['num_units']))
-        placements = validate_placements(validator, service, charm,
-                                         machines, machines_used)
-        if num_units is not None and len(placements) > num_units:
-            validator.add_error(
-                'too many units for service {}'.format(service_name))
-        validate_options(validator, service_name, service)
-
-
-def validate_placements(validator, service, charm, machines, machines_used):
-    """Validate all placement directives for a given service"""
-    if 'to' in service:
-        placements = service['to']
-        if not isinstance(placements, (list, tuple)):
+        if not isstring(service_name):
+            add_error('service name {} must be a string'.format(service_name))
+        # Validate and retrieve the service charm URL and number of units.
+        charm = _validate_charm(service.get('charm'), service_name, add_error)
+        num_units = _validate_num_units(
+            service.get('num_units'), service_name, add_error)
+        # Validate the service constraints, options and annotations.
+        label = 'service {}'.format(service_name)
+        _validate_constraints(service.get('constraints'), label, add_error)
+        _validate_options(service.get('options'), service_name, add_error)
+        _validate_annotations(service.get('annotations'), label, add_error)
+        # Retrieve and validate the service units placement.
+        placements = service.get('to', [])
+        if not islist(placements):
             placements = [placements]
+        if (num_units is not None) and (len(placements) > num_units):
+            add_error(
+                'too many units placed for service {}'.format(service_name))
         for placement in placements:
-            validate_placement(validator, placement, charm,
-                               machines, machines_used)
-        return placements
-    return []
+            machine_id = _validate_placement(
+                placement, services, machines, charm, add_error)
+            machine_ids.add(machine_id)
+
+    if machines is not None:
+        # Notify unused machines.
+        unused = set(machines).difference(machine_ids)
+        for machine_id in unused:
+            add_error(
+                'machine {} not referred to by a placement directive'
+                ''.format(machine_id))
 
 
-def validate_placement(validator, placement, charm, machines, machines_used):
+def _validate_charm(url, service_name, add_error):
+    """Validate the given charm URL.
+
+    Use the given service name to describe possible errors.
+    Use the given add_error callable to register validation error.
+
+    If the URL is valid, return the corresponding charm reference object.
+    Return None otherwise.
+    """
+    if url is None:
+        add_error('no charm specified for service {}'.format(service_name))
+        return None
+    if not isstring(url):
+        add_error(
+            'invalid charm specified for service {}: {}'
+            ''.format(service_name, url))
+        return None
+    if not url.strip():
+        add_error('empty charm specified for service {}'.format(service_name))
+        return None
+    try:
+        charm = references.Reference.from_string(url)
+    except ValueError as e:
+        msg = pyutils.exception_string(e)
+        add_error(
+            'invalid charm specified for service {}: {}'
+            ''.format(service_name, msg))
+        return None
+    if charm.is_local():
+        add_error(
+            'local charms not allowed for service {}: {}'
+            ''.format(service_name, charm))
+        return None
+    if charm.is_bundle():
+        add_error(
+            'bundle cannot be used as charm for service {}: {}'
+            ''.format(service_name, charm))
+        return None
+    return charm
+
+
+def _validate_num_units(num_units, service_name, add_error):
+    """Check that the given num_units is valid.
+
+    Use the given service name to describe possible errors.
+    Use the given add_error callable to register validation error.
+
+    If no errors are encountered, return the number of units as an integer.
+    Return None otherwise.
+    """
+    if num_units is None:
+        # This should be a subordinate charm.
+        return 0
+    try:
+        num_units = int(num_units)
+    except (TypeError, ValueError):
+        add_error(
+            'num_units for service {} must be a digit'.format(service_name))
+        return
+    if num_units < 0:
+        add_error(
+            'num_units {} for service {} must be a positive digit'
+            ''.format(num_units, service_name))
+        return
+    return num_units
+
+
+def _validate_constraints(constraints, label, add_error):
+    """Validate the given service or machine constraints.
+
+    Use the given label (e.g. "machine X" or "service Y") to describe
+    possible errors.
+    Use the given add_error callable to register validation error.
+    """
+    if constraints is None:
+        return
+    msg = '{} has invalid constraints {}'.format(label, constraints)
+    if not isstring(constraints):
+        add_error(msg)
+        return
+    sep = ',' if ',' in constraints else None
+    for constraint in constraints.split(sep):
+        try:
+            key, value = constraint.split('=')
+        except (TypeError, ValueError):
+            add_error(msg)
+            return
+        if key not in _CONSTRAINTS:
+            add_error(msg)
+
+
+def _validate_options(options, service_name, add_error):
+    """Lazily validate the options, ensuring that they are a dict.
+
+    Use the given add_error callable to register validation error.
+    """
+    if options is None:
+        return
+    if not isdict(options):
+        add_error('service {} has malformed options'.format(service_name))
+
+
+def _validate_annotations(annotations, label, add_error):
+    """Check that the given service or machine annotations are valid.
+
+    Use the given label (e.g. "machine X" or "service Y") to describe
+    possible errors.
+    Use the given add_error callable to register validation error.
+    """
+    if annotations is None:
+        return
+    if not isdict(annotations):
+        add_error('{} has invalid annotations {}'.format(label, annotations))
+        return
+    # Check that all the annotations keys are strings.
+    if not all(map(isstring, annotations)):
+        add_error(
+            '{} has invalid annotations: keys must be strings'.format(label))
+
+
+def _validate_placement(placement, services, machines, charm, add_error):
     """Validate a placement directive against other services.
+
+    Receive the placement (possibly as a string), the services and machines
+    bundle sections, the corresponding charm (or None if invalid) and the
+    add_error callable used to register validation errors.
 
     If applicable, also validate the placement of other machines within the
     bundle.
 
     Note that some of the logic within this differs between legacy and
     version 4 bundles.
+
+    Return the placement machine id if applicable, None otherwise.
     """
+    if not isstring(placement):
+        add_error(
+            'invalid placement {}: placement must be a string'
+            ''.format(placement))
+        return
+    is_legacy_bundle = machines is None
     try:
-        if validator.is_legacy_bundle():
+        if is_legacy_bundle:
+            # This is a v3 legacy bundle.
             unit_placement = models.parse_v3_unit_placement(placement)
+            # This is a v4 new style bundle.
         else:
             unit_placement = models.parse_v4_unit_placement(placement)
     except ValueError as e:
-        validator.add_error(pyutils.exception_string(e))
+        add_error(pyutils.exception_string(e))
         return
     if unit_placement.service:
-        if unit_placement.service not in validator.bundle['services']:
-            validator.add_error(
-                'placement {} refers to non-existant service {}'.format(
-                    placement, unit_placement.service))
+        service = services.get(unit_placement.service)
+        if service is None:
+            add_error(
+                'placement {} refers to non-existent service {}'
+                ''.format(placement, unit_placement.service))
             return
-        service = validator.bundle['services'][unit_placement.service]
-        if unit_placement.unit:
-            if int(unit_placement.unit) + 1 > int(service['num_units']):
-                validator.add_error(
-                    'placement {} specifies a unit greater than the '
-                    'units in service {}'.format(
-                        placement, unit_placement.service))
-    elif unit_placement.machine:
-        if (not validator.is_legacy_bundle() and
-                unit_placement.machine != 'new'):
-            machine = int(unit_placement.machine)
-            if machine not in machines:
-                validator.add_error(
-                    'placement {} refers to a non-existant machine '
-                    '{}'.format(placement, unit_placement.machine))
+        if unit_placement.unit is not None:
+            try:
+                num_units = int(service['num_units'])
+            except (TypeError, ValueError):
+                # This will be notified when validating the service itself.
+                pass
             else:
-                if charm:
-                    machine_series = machines[machine].get(
-                        'series', validator.bundle.get('series'))
-                    if machine_series != charm.series:
-                        validator.add_error(
-                            'charm {} cannot be deployed to machine with '
-                            'different series {}'.format(
-                                charm, machine_series))
-                if machine in machines_used:
-                    machines_used[machine] = True
+                if int(unit_placement.unit) + 1 > num_units:
+                    add_error(
+                        'placement {} specifies a unit greater than the units '
+                        'in service {}'
+                        ''.format(placement, unit_placement.service))
+    elif (
+        unit_placement.machine and
+        not is_legacy_bundle and
+        (unit_placement.machine != 'new')
+    ):
+        machine_id = int(unit_placement.machine)
+        machine = machines.get(machine_id)
+        if machine is None:
+            add_error(
+                'placement {} refers to a non-existent machine {}'
+                ''.format(placement, unit_placement.machine))
+            return
+        series = machine.get('series')
+        if charm.series and series and charm.series != series:
+            # If the machine series is invalid, ignore this check, as an error
+            # for the machine will be added elsewhere.
+            errors = []
+            _validate_series(series, '', errors.append)
+            if not errors:
+                add_error(
+                    'charm {} cannot be deployed to machine with different '
+                    'series {}'.format(charm, series))
+        return machine_id
 
 
-def validate_relations(validator):
-    """Validate relations, ensuring that the endpoints exist."""
-    relations = validator.bundle.get('relations', [])
-    if not isinstance(relations, (list, tuple)):
-        validator.add_error('relations {} are malformed'.format(relations))
+def _validate_machines(machines, add_error):
+    """Validate the given machines section.
+
+    Validation includes machines constraints, series and annotations.
+    Use the given add_error callable to register validation error.
+    """
+    if not machines:
+        return
+    for machine_id, machine in machines.items():
+        if machine_id < 0:
+            add_error(
+                'machine {} has an invalid id, must be positive digit'
+                ''.format(machine_id))
+        label = 'machine {}'.format(machine_id)
+        _validate_constraints(machine.get('constraints'), label, add_error)
+        _validate_series(machine.get('series'), label, add_error)
+        _validate_annotations(machine.get('annotations'), label, add_error)
+
+
+def _validate_relations(relations, services, add_error):
+    """Validate relations, ensuring that the endpoints exist.
+
+    Receive the relations and services bundle sections.
+    Use the given add_error callable to register validation error.
+    """
+    if not relations:
         return
     for relation in relations:
-        if not isinstance(relation, (list, tuple)):
-            validator.add_error('relation {} is malformed'.format(relation))
+        if not islist(relation):
+            add_error('relation {} is malformed'.format(relation))
             continue
+        relation_str = ' -> '.join('{}'.format(i) for i in relation)
         for endpoint in relation:
+            if not isstring(endpoint):
+                add_error(
+                    'relation {} has malformed endpoint {}'
+                    ''.format(relation_str, endpoint))
+                continue
             try:
                 service, _ = endpoint.split(':')
             except ValueError:
                 service = endpoint
-            if service not in validator.bundle['services']:
-                validator.add_error(
-                    'relation {} refers to a non-existant service '
-                    '{}'.format(relation, service))
-
-
-def validate_options(validator, service_name, service):
-    """Lazily validate the options, ensuring that they are a dict."""
-    if ('options' in service and
-            not isinstance(service['options'], collections.Mapping)):
-        validator.add_error(
-            'service {} has malformed options'.format(service_name))
+            if service not in services:
+                add_error(
+                    'relation {} endpoint {} refers to a non-existent service '
+                    '{}'.format(relation_str, endpoint, service))


### PR DESCRIPTION
Improve the validation logic by:
- simplifying error management and code flow;
- making each function only receive what strictly required;
- adding more strict type checks;
- adding service annotations validation;
- fixing some subtle bugs in unit placement
  when the unit is 0;
- separating internal validation functions into
  more reusable bits;
- changing the validation tests so that each
  test is executed separately, with a real
  bundle content;
- changing the validation tests so that only
  the public API is exercised.

Also simplify the validation public API:
the validate function is the only exposed
API now.

Also ensure there are no false positives when
validating bundles by testing the validation
logic against the currently ingested bundle
in the charm store. This is done with a functional
test requiring network access.

QA:
`make test`
`make fcheck` (this will take a minute).

My apologies for the long diff, but lots of code are tests and I didn't find an easy way to subdivide the work. Thanks a lot!