### PR TITLE
Improve unit placement and integration tests.

### DIFF
--- a/jujubundlelib/__init__.py
+++ b/jujubundlelib/__init__.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 
 
-VERSION = (0, 1, 5)
+VERSION = (0, 1, 6)
 
 
 def get_version():

--- a/jujubundlelib/changeset.py
+++ b/jujubundlelib/changeset.py
@@ -149,31 +149,34 @@ def _handle_units_placement(changeset, units, records):
         if placement_directives and not changeset.is_legacy_bundle():
             placement_directives += placement_directives[-1:] * \
                 (service['num_units'] - len(placement_directives))
+        placed_in_services = {}
         for i in range(service['num_units']):
             unit = units['{}/{}'.format(service_name, i)]
             record = records[unit['record']]
             if i < len(placement_directives):
                 record = _handle_unit_placement(
-                    changeset, units, unit, record, placement_directives[i])
+                    changeset, units, unit, record, placement_directives[i],
+                    placed_in_services)
             changeset.send(record)
 
 
 def _handle_unit_placement(
-        changeset, units, unit, record, placement_directive):
+        changeset, units, unit, record, placement_directive,
+        placed_in_services):
     record = copy.deepcopy(record)
     if changeset.is_legacy_bundle():
         placement = models.parse_v3_unit_placement(placement_directive)
     else:
         placement = models.parse_v4_unit_placement(placement_directive)
     if placement.machine:
+        # The unit is placed on a machine.
         if placement.machine == 'new':
-            machine_record_id = 'addMachines-{}'.format(
-                changeset.next_action())
+            parent_record_id = 'addMachines-{}'.format(changeset.next_action())
             options = {}
             if placement.container_type:
                 options = {'containerType': placement.container_type}
             changeset.send({
-                'id': machine_record_id,
+                'id': parent_record_id,
                 'method': 'addMachines',
                 'args': [options],
                 'requires': [],
@@ -182,21 +185,36 @@ def _handle_unit_placement(
             if changeset.is_legacy_bundle():
                 record['args'][2] = '0'
                 return record
-            machine_record_id = changeset.machines_added[
-                placement.machine]
+            parent_record_id = changeset.machines_added[placement.machine]
             if placement.container_type:
-                machine_record_id = _handle_container_placement(
-                    changeset, placement, machine_record_id)
+                parent_record_id = _handle_container_placement(
+                    changeset, placement, parent_record_id)
     else:
-        placement_unit = '{}/{}'.format(
-            placement.service, placement.unit)
-        machine_record_id = units[placement_unit]['record']
+        # The unit is placed to a unit or to a service.
+        service = placement.service
+        unit_number = placement.unit
+        if unit_number is None:
+            unit_number = _next_unit_in_service(service, placed_in_services)
+        placement_unit = '{}/{}'.format(service, unit_number)
+        parent_record_id = units[placement_unit]['record']
         if placement.container_type:
-                machine_record_id = _handle_container_placement(
-                    changeset, placement, machine_record_id)
-    record['requires'].append(machine_record_id)
-    record['args'][2] = '${}'.format(machine_record_id)
+                parent_record_id = _handle_container_placement(
+                    changeset, placement, parent_record_id)
+    record['requires'].append(parent_record_id)
+    record['args'][2] = '${}'.format(parent_record_id)
     return record
+
+
+def _next_unit_in_service(service, placed_in_services):
+    """Return the unit number where to place a unit placed on a service.
+
+    Receive the service name and a dict mapping service names to the current
+    number of placed units in that service.
+    """
+    current = placed_in_services.get(service)
+    number = 0 if current is None else current + 1
+    placed_in_services[service] = number
+    return number
 
 
 def _handle_container_placement(changeset, placement, machine_record_id):

--- a/jujubundlelib/tests/test_changeset.py
+++ b/jujubundlelib/tests/test_changeset.py
@@ -293,6 +293,11 @@ class TestHandleUnits(unittest.TestCase):
         changeset.handle_units(cs)
         self.assertEqual([], cs.recv())
 
+    def test_subordinate_service(self):
+        cs = changeset.ChangeSet({'services': {'logger': {'charm': 'logger'}}})
+        changeset.handle_units(cs)
+        self.assertEqual([], cs.recv())
+
     def test_unit_in_new_machine(self):
         cs = changeset.ChangeSet({
             'services': OrderedDict((

--- a/jujubundlelib/tests/test_integration.py
+++ b/jujubundlelib/tests/test_integration.py
@@ -9,6 +9,7 @@ from __future__ import (
 import json
 import os
 import pprint
+import traceback
 import unittest
 try:
     from urllib.request import (
@@ -76,10 +77,17 @@ class TestFunctional(unittest.TestCase):
             except HTTPError as err:
                 print('skipping {}: {}'.format(ref, err))
                 continue
+            # Check bundle validation.
             errors = validation.validate(bundle)
             self.assertEqual(
                 [], errors,
                 'ref: {}\n{}\nerrors: {}'.format(
                     ref, pprint.pformat(bundle), errors))
-            changes = changeset.parse(bundle)
+            # Check change set generation.
+            try:
+                changes = list(changeset.parse(bundle))
+            except:
+                msg = 'changeset parsing error\nref: {}\n{}\n{}'.format(
+                    ref, pprint.pformat(bundle), traceback.format_exc())
+                self.fail(msg)
             self.assertTrue(changes)


### PR DESCRIPTION
This branch fixes some errors when parsing the bundle to generate the change set.
Those errors were not detected by the functional test because its implementation was naive: we did not realize the generator object, which of course is always True.

So the functional tests are now fixed and the following two scenarios are handled:
- a unit is placed to a service;
- a service does not define num_units.

This should fix some of the QA errors encountered at https://github.com/juju/juju-gui/pull/720