### PR TITLE
Do not crash with a traceback if a machine value is unset

### DIFF
--- a/jujubundlelib/__init__.py
+++ b/jujubundlelib/__init__.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 
 
-VERSION = (0, 1, 8)
+VERSION = (0, 1, 9)
 
 
 def get_version():

--- a/jujubundlelib/changeset.py
+++ b/jujubundlelib/changeset.py
@@ -91,6 +91,9 @@ def handle_services(changeset):
 def handle_machines(changeset):
     """Populate the change set with addMachines changes."""
     for machine_name, machine in changeset.bundle.get('machines', {}).items():
+        if machine is None:
+            # We allow the machine value to be unset in the YAML.
+            machine = {}
         record_id = 'addMachines-{}'.format(changeset.next_action())
         changeset.send({
             'id': record_id,

--- a/jujubundlelib/tests/test_changeset.py
+++ b/jujubundlelib/tests/test_changeset.py
@@ -224,6 +224,16 @@ class TestHandleMachines(unittest.TestCase):
         changeset.handle_machines(cs)
         self.assertEqual([], cs.recv())
 
+    def test_none_machine(self):
+        cs = changeset.ChangeSet({'machines': {42: None}})
+        changeset.handle_machines(cs)
+        self.assertEqual([{
+            'id': 'addMachines-0',
+            'method': 'addMachines',
+            'args': [{'constraints': {}, 'series': ''}],
+            'requires': [],
+        }], cs.recv())
+
 
 class TestHandleRelations(unittest.TestCase):
 

--- a/jujubundlelib/tests/test_validation.py
+++ b/jujubundlelib/tests/test_validation.py
@@ -43,6 +43,19 @@ _validation_tests = {
             'machines': {1: {}},
         },
     ),
+    'test_valid_bundle_machines_none': (
+        [],
+        {
+            'services': {
+                'django': {
+                    'charm': 'cs:trusty/django-42',
+                    'num_units': 1,
+                    'to': ['1'],
+                },
+            },
+            'machines': {1: None},
+        },
+    ),
     'test_valid_bundle_relations': (
         [],
         {
@@ -593,6 +606,19 @@ _validation_tests = {
                 },
                 '-47': {},
             },
+        },
+    ),
+    'test_invalid_machines_type': (
+        ['machine 1 does not appear to be well-formed'],
+        {
+            'services': {
+                'django': {
+                    'charm': 'cs:trusty/django-42',
+                    'num_units': 1,
+                    'to': ['1'],
+                },
+            },
+            'machines': {1: 42},
         },
     ),
     'test_invalid_machines_constraints': (

--- a/jujubundlelib/validation.py
+++ b/jujubundlelib/validation.py
@@ -339,7 +339,8 @@ def _validate_placement(placement, services, machines, charm, add_error):
             return
         machine = machines[machine_id]
         if not isdict(machine):
-            # This error is notified while validating machines.
+            # Ignore this error here, as it is emitted while validating the
+            # machines section of the bundle.
             machine = {}
         # If the unit is "hulk smashed", then we need to check that the charm
         # and the machine series match.

--- a/jujubundlelib/validation.py
+++ b/jujubundlelib/validation.py
@@ -330,12 +330,17 @@ def _validate_placement(placement, services, machines, charm, add_error):
         (unit_placement.machine != 'new')
     ):
         machine_id = int(unit_placement.machine)
-        machine = machines.get(machine_id)
-        if machine is None:
+        # A machine can be included in machines but its value can be None.
+        # This is so that we are compatible with go-style YAML unmarshaling.
+        if machine_id not in machines:
             add_error(
                 'placement {} refers to a non-existent machine {}'
                 ''.format(placement, unit_placement.machine))
             return
+        machine = machines[machine_id]
+        if not isdict(machine):
+            # This error is notified while validating machines.
+            machine = {}
         # If the unit is "hulk smashed", then we need to check that the charm
         # and the machine series match.
         if not unit_placement.container_type:
@@ -365,6 +370,13 @@ def _validate_machines(machines, add_error):
             add_error(
                 'machine {} has an invalid id, must be positive digit'
                 ''.format(machine_id))
+        if machine is None:
+            continue
+        elif not isdict(machine):
+            add_error(
+                'machine {} does not appear to be well-formed'
+                ''.format(machine_id))
+            continue
         label = 'machine {}'.format(machine_id)
         _validate_constraints(machine.get('constraints'), label, add_error)
         _validate_series(machine.get('series'), label, add_error)


### PR DESCRIPTION
Handle the case in which the machines section includes a machine without a definition, like:
```
machines:
    1:
```
Both validation and changeset generation crashed with a YAML like that.
The tests should demonstrate the new behavior.

Please `make check`.