### PR TITLE
Move to a more consistent changeset format.

### DIFF
--- a/jujubundlelib/__init__.py
+++ b/jujubundlelib/__init__.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 
 
-VERSION = (0, 1, 9)
+VERSION = (0, 2, 0)
 
 
 def get_version():

--- a/jujubundlelib/validation.py
+++ b/jujubundlelib/validation.py
@@ -24,6 +24,7 @@ _CONSTRAINTS = (
     'mem',
     'networks',
     'root-disk',
+    'spaces',
     'tags',
 )
 


### PR DESCRIPTION
Specifically:

1) the id prefix for changes with method == "deploy" is now "deploy" and
   no longer "addService".

2) arguments for deploy changes now include the service constraints. Moreover,
while the first argument was previously set to a charm URL, it is now a
placeholder pointing to the corresponding addCharm change instead.
Before: args: ['cs:django-42', 'django', {option: value}]
Now:    args: ['$addCharm-12', 'django', {option: value}, 'constraint=value']

3) arguments for addUnit changes no longer include the number of units
(that was previously always set to 1).

Also allow the "spaces" constraint and bump version up a little.
The result is now more deterministic as services and machines are ordered by name before being processed.