### PR TITLE
Improve reference.copy() so that it is possible to override attributes.

### DIFF
--- a/jujubundlelib/__init__.py
+++ b/jujubundlelib/__init__.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 
 
-VERSION = (0, 3, 0)
+VERSION = (0, 3, 1)
 
 
 def get_version():

--- a/jujubundlelib/references.py
+++ b/jujubundlelib/references.py
@@ -161,11 +161,23 @@ class Reference(object):
             (self.schema, self.user, self.name) ==
             (other.schema, other.user, other.name))
 
-    def copy(self):
-        """Copy this reference."""
-        return self.__class__(
+    def copy(self, **kwargs):
+        """Copy this reference.
+
+        If keyword arguments are passed, the copied reference will have the
+        corresponding attributes.
+        For instance:
+
+            ref = reference.copy()
+            ref = reference.copy(revision=42)
+            ref = reference.copy(channel='', user='')
+        """
+        reference = self.__class__(
             self.schema, self.user, self.channel, self.series, self.name,
             self.revision)
+        for key, value in kwargs.items():
+            setattr(reference, key, value)
+        return reference
 
     def jujucharms_id(self):
         """Return the identifier of this reference in jujucharms.com."""

--- a/jujubundlelib/tests/test_references.py
+++ b/jujubundlelib/tests/test_references.py
@@ -174,6 +174,18 @@ class TestReference(unittest.TestCase):
         self.assertIsNot(ref, copied_ref)
         self.assertEqual(ref, copied_ref)
 
+    def test_copy_with_attributes(self):
+        # The reference can be copied overriding specific attributes.
+        ref = make_reference()
+        copy1 = ref.copy(channel=references.DEVELOPMENT_CHANNEL)
+        copy2 = ref.copy(user='', series='wily', revision=0)
+        self.assertNotEqual(ref, copy1)
+        self.assertNotEqual(ref, copy2)
+        self.assertEqual('cs:~myuser/precise/juju-gui-42', str(ref))
+        self.assertEqual(
+            'cs:~myuser/development/precise/juju-gui-42', str(copy1))
+        self.assertEqual('cs:wily/juju-gui-0', str(copy2))
+
     def test_jujucharms_id(self):
         # It is possible to return the reference identifier in jujucharms.com.
         for ref, expected_value in self.jujucharms_tests:


### PR DESCRIPTION
This just enables some sugar for callers.